### PR TITLE
Update README.md with Ruby 3.1+ support info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ services.
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 2.7+.
+This library is supported on Ruby 3.1+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Currently, this means Ruby 2.7 and later. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 


### PR DESCRIPTION
- seen 3.1+ is still tested on CI
- 3.1 is EOL also, I'm happy to submit other PR to remove it from CI